### PR TITLE
WIP Update provision.sh to only restart nginx if active.

### DIFF
--- a/files/scripts/provision.sh
+++ b/files/scripts/provision.sh
@@ -18,6 +18,5 @@ fi
 
 systemctl reload apache2
 
-if [ "$(systemctl is-active nginx)" != "unknown" ]; then
-    systemctl reload nginx
-fi
+# Only try to reload nginx if it is installed and running
+(systemctl is-active --quiet nginx && nginx -t && systemctl reload nginx) || true


### PR DESCRIPTION
Jessie would return unknown whereas Buster returns inactive if not running. This solution cleans it up a bit.