### PR TITLE
Support better parallel execution by prefixing uniqid with vhost

### DIFF
--- a/files/scripts/provision.sh
+++ b/files/scripts/provision.sh
@@ -17,8 +17,8 @@ fi
 systemctl reload apache2
 
 # Only try to setup SSL and reload nginx if it is installed and running
-if [ systemctl is-active --quiet nginx ]; then
+if [[ $(systemctl is-active --quiet nginx) -eq 0 ]]; then
     # Install SSL Certificates and reload Nginx
     /opt/muna/scripts/setup_ssl "${NAMESPACE}"
-    systemctl reload nginx
+    nginx -t && systemctl reload nginx
 fi

--- a/files/scripts/provision.sh
+++ b/files/scripts/provision.sh
@@ -14,9 +14,11 @@ fi
 
 /opt/muna/scripts/setup_ssenv "${NAMESPACE}"
 /opt/muna/scripts/setup_secrets "${NAMESPACE}"
-/opt/muna/scripts/setup_ssl "${NAMESPACE}"
-
 systemctl reload apache2
 
-# Only try to reload nginx if it is installed and running
-(systemctl is-active --quiet nginx && nginx -t && systemctl reload nginx) || true
+# Only try to setup SSL and reload nginx if it is installed and running
+if [ systemctl is-active --quiet nginx ]; then
+    # Install SSL Certificates and reload Nginx
+    /opt/muna/scripts/setup_ssl "${NAMESPACE}"
+    systemctl reload nginx
+fi

--- a/files/scripts/setup_secrets
+++ b/files/scripts/setup_secrets
@@ -22,7 +22,7 @@ if (!file_exists($outputPath) || !is_dir($outputPath)) {
     mkdir($outputPath, 0755, true);
 }
 
-$outputTemporaryPath = sprintf("%s/muna_tmp_%s", sys_get_temp_dir(), uniqid());
+$outputTemporaryPath = sprintf("%s/muna_tmp_%s", sys_get_temp_dir(), uniqid($vhost));
 mkdir($outputTemporaryPath);
 
 // Loop through each vault and obtain any secrets in them

--- a/files/scripts/setup_ssl
+++ b/files/scripts/setup_ssl
@@ -50,7 +50,7 @@ $paths = [
 ];
 
 // Download each path from Muna into a temporary directory
-$sslTemporaryPath = sprintf("%s/muna_tmp_%s", sys_get_temp_dir(), uniqid());
+$sslTemporaryPath = sprintf("%s/muna_tmp_%s", sys_get_temp_dir(), uniqid($vhost));
 mkdir($sslTemporaryPath);
 foreach ($paths as $path) {
     output(sprintf("Processing path '%s'", $path));


### PR DESCRIPTION
When deploying vhosts, muna is executed in parallel. This can result in setup_* executions to be triggered at the same exact time on different vhosts.

As PHP's `uniqid` by default is based on unixtimestamp, if executions happen within the same second, then they will attempt to use the same temporary directory. However cleanup is performed on these directories and can remove them unexpectedly from parallel executions.

This change adds the vhost parameter as a prefix to temporary directories using `uniqid` to ensure there is no conflict when running in parallel with vhost deployments (e.g. full-deploy).